### PR TITLE
Pass the request object as the first argument to authenticate()

### DIFF
--- a/admin_sso/auth.py
+++ b/admin_sso/auth.py
@@ -11,7 +11,7 @@ class DjangoSSOAuthBackend(object):
         except cls.DoesNotExist:
             return None
 
-    def authenticate(self, request=None, **kwargs):
+    def authenticate(self, request, **kwargs):
         sso_email = kwargs.pop("sso_email", None)
 
         assignment = Assignment.objects.for_email(sso_email)

--- a/admin_sso/tests/test_auth.py
+++ b/admin_sso/tests/test_auth.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from admin_sso import settings
 from admin_sso.auth import DjangoSSOAuthBackend
@@ -20,18 +20,21 @@ class AuthModuleTests(TestCase):
             user=self.user,
             weight=100,
         )
+        self.request_factory = RequestFactory()
 
     def tearDown(self):
         self.user.delete()
         Assignment.objects.all().delete()
 
     def test_empty_authenticate(self):
-        user = self.auth_module.authenticate()
+        request = self.request_factory.get('/')
+        user = self.auth_module.authenticate(request)
         self.assertEqual(user, None)
 
     def test_simple_assignment(self):
         email = "foo@example.com"
-        user = self.auth_module.authenticate(sso_email=email)
+        request = self.request_factory.get('/')
+        user = self.auth_module.authenticate(request, sso_email=email)
         self.assertEqual(user, self.user)
 
     def test_get_user(self):

--- a/admin_sso/tests/test_auth.py
+++ b/admin_sso/tests/test_auth.py
@@ -27,13 +27,13 @@ class AuthModuleTests(TestCase):
         Assignment.objects.all().delete()
 
     def test_empty_authenticate(self):
-        request = self.request_factory.get('/')
+        request = self.request_factory.get("/")
         user = self.auth_module.authenticate(request)
         self.assertEqual(user, None)
 
     def test_simple_assignment(self):
         email = "foo@example.com"
-        request = self.request_factory.get('/')
+        request = self.request_factory.get("/")
         user = self.auth_module.authenticate(request, sso_email=email)
         self.assertEqual(user, self.user)
 

--- a/admin_sso/views.py
+++ b/admin_sso/views.py
@@ -55,7 +55,7 @@ def end(request):
 
     if credentials.id_token["email_verified"]:
         email = credentials.id_token["email"]
-        user = authenticate(sso_email=email)
+        user = authenticate(request, sso_email=email)
         if user and user.is_active:
             login(request, user)
             return HttpResponseRedirect(reverse("admin:index"))


### PR DESCRIPTION
Django 1.11 started passing the request object to auth backends.
Django 2.1+ requires auth backends to accept the request object as their
first position argument. django-admin-sso should pass the request object
to authenticate() to be a good citizen.

This change allows subclasses of DjangoSSOAuthBackend to add error messages
via Django's messages framework, which requires the request object to work.

Fixes #5 