### PR TITLE
Add redirect to next page on login

### DIFF
--- a/admin_sso/templates/admin_sso/login.html
+++ b/admin_sso/templates/admin_sso/login.html
@@ -4,5 +4,5 @@
 
 {% block content %}
 {{ block.super }}
-<a href="{% url 'admin:admin_sso_assignment_start' %}">{% trans "Log in using SSO" %}</a>
+<a href="{% url 'admin:admin_sso_assignment_start' %}?next={{ next }}">{% trans "Log in using SSO" %}</a>
 {% endblock content %}

--- a/admin_sso/views.py
+++ b/admin_sso/views.py
@@ -1,9 +1,14 @@
+from functools import wraps
+
 from django.contrib.auth import authenticate, login
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from oauth2client.client import FlowExchangeError, OAuth2WebServerFlow
 
 from admin_sso import settings
+
+REDIRECT_COOKIE_NAME = "admin_sso-next"
 
 
 flow_kwargs = {
@@ -23,6 +28,31 @@ if settings.DJANGO_ADMIN_SSO_REVOKE_URI:
 flow_override = None
 
 
+def set_next_cookie(view):
+    @wraps(view)
+    def fn(request, *args, **kwargs):
+        response = view(request, *args, **kwargs)
+        if request.GET.get("next"):
+            response.set_cookie(REDIRECT_COOKIE_NAME, request.GET["next"], max_age=600)
+        return response
+
+    return fn
+
+
+def retrieve_next(request):
+    next = request.COOKIES.get(REDIRECT_COOKIE_NAME)
+    return (
+        next
+        if url_has_allowed_host_and_scheme(
+            url=next,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        )
+        else None
+    )
+
+
+@set_next_cookie
 def start(request):
     flow = OAuth2WebServerFlow(
         redirect_uri=request.build_absolute_uri(
@@ -58,7 +88,9 @@ def end(request):
         user = authenticate(request, sso_email=email)
         if user and user.is_active:
             login(request, user)
-            return HttpResponseRedirect(reverse("admin:index"))
+            return HttpResponseRedirect(
+                retrieve_next(request) or reverse("admin:index")
+            )
 
     # if anything fails redirect to admin:index
     return HttpResponseRedirect(reverse("admin:index"))


### PR DESCRIPTION
Hi Matthias, I've implemented redirection to the page specified by the "next" query param on the login page, using the same approach (and nearly identical code) as your [django-authlib](https://github.com/matthiask/django-authlib). I noticed there are some others who have asked about this (#9) so I figured I'd shoot over this PR. Let me know if there are any other changes you'd like me to include. Thanks for keeping this package up and running!

Closes #9